### PR TITLE
feat: Navigate the timeline using the left - right keys

### DIFF
--- a/src/components/Scrubber.vue
+++ b/src/components/Scrubber.vue
@@ -9,6 +9,8 @@
       }
     ]"
     :style="{ '--max-height': `${contentHeight}px` }"
+    @keyup.arrow-left="gotoEvent(-1)"
+    @keyup.arrow-right="gotoEvent(1)"
   >
     <transition name="event-card">
       <EventCard v-if="activeEvent !== null" :key="`event-${activeEvent.id}`" :event="activeEvent" />


### PR DESCRIPTION
### Navigation of the timeline using the arrow keys
A fix for https://github.com/Palanaeum/roshar-map/issues/70

I used the [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) as specified in the [Vue documentation](https://vuejs.org/v2/guide/events.html#Key-Modifiers)